### PR TITLE
Fix EFT weekend adjustments

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -19,7 +19,13 @@ import { draculaTheme, lightTheme } from './theme'; // Corrected import for name
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import axios from 'axios';
-import { isWithinInterval, compareAsc, isWeekend, addDays, parseISO } from 'date-fns';
+import {
+  isWithinInterval,
+  compareAsc,
+  isWeekend,
+  addDays,
+  parseISO,
+} from 'date-fns';
 import BillList from './components/BillList';
 import BillManager from './components/BillManager';
 import PayPeriodSelector from './components/PayPeriodSelector';
@@ -80,15 +86,24 @@ function App() {
       const paymentKey = `${payPeriodIndex}_${bill.dueDate.toISOString()}`;
       const isPaid = bill.paymentHistory && bill.paymentHistory[paymentKey];
 
+      const originalDueDate = bill.dueDate;
+
       if (
         adjustEFT &&
         bill.transactionType === 'EFT' &&
         !isPaid &&
         isWeekend(bill.dueDate)
       ) {
-        // Move to the following Monday
-        bill.dueDate = addDays(bill.dueDate, 8 - bill.dueDate.getDay());
+        const daysToAdd = bill.dueDate.getDay() === 6 ? 2 : 1;
+        bill = {
+          ...bill,
+          originalDueDate,
+          dueDate: addDays(bill.dueDate, daysToAdd),
+        };
+      } else {
+        bill = { ...bill, originalDueDate };
       }
+
       return bill;
     });
 

--- a/frontend/src/components/BillList.jsx
+++ b/frontend/src/components/BillList.jsx
@@ -55,7 +55,8 @@ function BillList({ bills, togglePaid, deleteBill, updateBill, currentPayPeriod 
   const handleTogglePaid = (bill) => {
     if (bill && bill.id) {
       console.log(`Toggling paid status for bill: ${bill.name} (ID: ${bill.id})`);
-      togglePaid(bill.id, bill.dueDate);
+      const canonicalDate = bill.originalDueDate || bill.dueDate;
+      togglePaid(bill.id, canonicalDate);
     } else {
       console.error("Attempted to toggle paid status for a bill without a valid 'id'.", bill);
     }
@@ -76,7 +77,8 @@ function BillList({ bills, togglePaid, deleteBill, updateBill, currentPayPeriod 
   const completedBills = [];
 
   validBills.forEach((bill) => {
-    const dueDate = new Date(bill.dueDate);
+    const canonicalDate = bill.originalDueDate || bill.dueDate;
+    const dueDate = new Date(canonicalDate);
     if (isNaN(dueDate)) {
       console.warn(`Bill "${bill.name}" has an invalid 'dueDate' and will be treated as outstanding.`);
       outstandingBills.push(bill);
@@ -105,7 +107,8 @@ function BillList({ bills, togglePaid, deleteBill, updateBill, currentPayPeriod 
 
   const renderBills = (billsToRender) =>
     billsToRender.map((bill) => {
-      const dueDate = new Date(bill.dueDate);
+      const canonicalDate = bill.originalDueDate || bill.dueDate;
+      const dueDate = new Date(canonicalDate);
       const paymentKey = `${payPeriodIndex}_${dueDate.toISOString()}`;
       const isPaid = bill.paymentHistory && bill.paymentHistory[paymentKey];
 


### PR DESCRIPTION
## Summary
- ensure EFT weekend adjustments only move to Monday
- preserve payment status when toggling weekend adjustments

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6849b9f86684833186eecf1d6867d543