### PR TITLE
Add Docker packaging and publish workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+frontend/node_modules
+backend/node_modules
+frontend/build
+coverage
+.git

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,44 @@
+name: Build and Publish Docker image
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Determine version
+        id: vars
+        run: |
+          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+            echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.VERSION }}
+            ghcr.io/${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Build stage
+FROM node:18 AS builder
+WORKDIR /app
+
+# Install backend dependencies
+COPY backend/package*.json ./backend/
+RUN cd backend && npm install --production
+
+# Build frontend
+COPY frontend/package*.json ./frontend/
+RUN cd frontend && npm install
+COPY frontend ./frontend
+RUN cd frontend && npm run build
+
+# Copy backend source
+COPY backend ./backend
+
+# Final stage
+FROM node:18-slim
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Copy built artifacts and backend
+COPY --from=builder /app/backend ./backend
+COPY --from=builder /app/frontend/build ./frontend/build
+
+EXPOSE 5000
+CMD ["node", "backend/index.js"]


### PR DESCRIPTION
## Summary
- add Dockerfile for running backend with built frontend
- ignore build artifacts in docker context
- add workflow to build and publish container image to GHCR on pushes and tags

## Testing
- `cd backend && npm test -- -t ''`
- `cd frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6849c01da7cc833187f5db68e14f9239