### PR TITLE
Add env vars for port and timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,13 @@ COPY backend ./backend
 FROM node:18-slim
 WORKDIR /app
 ENV NODE_ENV=production
+ENV PORT=7864
+ENV TZ=UTC
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata && rm -rf /var/lib/apt/lists/*
 
 # Copy built artifacts and backend
 COPY --from=builder /app/backend ./backend
 COPY --from=builder /app/frontend/build ./frontend/build
 
-EXPOSE 5000
+EXPOSE 7864
 CMD ["node", "backend/index.js"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Start the backend API and the React client concurrently:
 npm start
 ```
 
-The API listens on port `5000` and the React development server runs on port `3000`. The frontend reads the API base URL from `frontend/baseurl.env` which defaults to `http://localhost:5000`.
+The API listens on port `7864` by default and the React development server runs on port `3000`. The frontend reads the API base URL from `frontend/baseurl.env` which defaults to `http://localhost:7864`.
 
 ## Building for production
 
@@ -31,6 +31,28 @@ npm run build
 ```
 
 This creates the production build of the React app in `frontend/build`.
+
+## Docker deployment
+
+Build the Docker image:
+
+```bash
+docker build -t billy .
+```
+
+Run the container while publishing the port and optionally setting the time zone:
+
+```bash
+docker run -p 7864:7864 \
+  -e PORT=7864 \
+  -e TZ=America/New_York \
+  billy
+```
+
+Available environment variables:
+
+- `PORT` - Port the Express server listens on (default `7864`).
+- `TZ` - Time zone used by the container (default `UTC`).
 
 ## Running tests
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -6,7 +6,9 @@ const bodyParser = require('body-parser');
 const path = require('path');
 const db = require('./db');
 const app = express();
-const PORT = process.env.PORT || 5000;
+// Set default timezone if TZ env variable is not provided
+process.env.TZ = process.env.TZ || 'UTC';
+const PORT = parseInt(process.env.PORT, 10) || 7864;
 
 // Middleware
 app.use(cors());

--- a/frontend/baseurl.env
+++ b/frontend/baseurl.env
@@ -1,1 +1,1 @@
-REACT_APP_API_BASE_URL=http://localhost:5000
+REACT_APP_API_BASE_URL=http://localhost:7864


### PR DESCRIPTION
## Summary
- allow backend server port to be overridden and default to 7864
- install tzdata and expose port 7864 in Dockerfile
- update base URL for the frontend
- document Docker usage with environment variables

## Testing
- `npm test` in `backend`
- `npm test -- --watchAll=false` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6849d9fc105c8331be2aaaf269cababe