### PR TITLE
Improve container CI path filtering

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches: ["main"]
     tags: ["v*"]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker-publish.yml"
+      - "backend/**"
+      - "frontend/**"
+      - "package.json"
+      - "package-lock.json"
+      - "backend/package.json"
+      - "backend/package-lock.json"
+      - "frontend/package.json"
+      - "frontend/package-lock.json"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- only run container publish pipeline when app or container files change

## Testing
- `npm test` in `backend`
- `npm test -- --watchAll=false` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6849dd9fc4e08331bfa700e1b85a22bb