### PR TITLE
Allow uid/gid via UID/GID env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,15 +17,26 @@ COPY backend ./backend
 
 # Final stage
 FROM node:18-slim
+
+# Runtime user will be created based on UID/GID environment variables
+# provided when the container starts.
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=7864
 ENV TZ=UTC
-RUN apt-get update && apt-get install -y --no-install-recommends tzdata && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends tzdata gosu && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy built artifacts and backend
 COPY --from=builder /app/backend ./backend
+
 COPY --from=builder /app/frontend/build ./frontend/build
+
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 EXPOSE 7864
 CMD ["node", "backend/index.js"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ and mapping a host directory for persistent data:
 docker run -p 7864:7864 \
   -e PORT=7864 \
   -e TZ=America/New_York \
+  -e UID=$(id -u) \
+  -e GID=$(id -g) \
   -v $(pwd)/data:/app/backend/data \
   billy
 ```
@@ -59,6 +61,8 @@ Available environment variables:
 
 - `PORT` - Port the Express server listens on (default `7864`).
 - `TZ` - Time zone used by the container (default `UTC`).
+- `UID` - UID for the `billy` user created at runtime (default `1000`).
+- `GID` - GID for the `billy` group created at runtime (default `1000`).
 
 ### Docker Compose example
 
@@ -71,6 +75,8 @@ services:
       - "7864:7864"
     environment:
       - TZ=America/New_York
+      - UID=${UID:-1000}
+      - GID=${GID:-1000}
     volumes:
       - ./data:/app/backend/data
 ```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+USER_ID="${UID:-1000}"
+GROUP_ID="${GID:-1000}"
+
+# create group if it doesn't exist
+if ! getent group billy >/dev/null 2>&1; then
+    addgroup --gid "$GROUP_ID" billy
+fi
+
+# create user if it doesn't exist
+if ! id -u billy >/dev/null 2>&1; then
+    adduser --disabled-password --gecos "" --uid "$USER_ID" --gid "$GROUP_ID" billy
+fi
+
+chown -R billy:billy /app
+
+exec gosu billy "$@"


### PR DESCRIPTION
## Summary
- create a docker-entrypoint script that adds the `billy` user at runtime using UID/GID environment variables
- install gosu and use the entrypoint in the Dockerfile
- document new runtime environment variables in README

## Testing
- `cd backend && npm install && npm test`
- `cd ../frontend && npm install && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6849dfd631d083319c64d276ef111617