### PR TITLE
Fix runtime UID/GID handling

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,17 +3,22 @@ set -e
 
 USER_ID="${UID:-1000}"
 GROUP_ID="${GID:-1000}"
+USER_NAME="billy"
 
-# create group if it doesn't exist
-if ! getent group billy >/dev/null 2>&1; then
-    addgroup --gid "$GROUP_ID" billy
+# create group with the desired GID if one doesn't already exist
+if ! getent group "$GROUP_ID" >/dev/null 2>&1; then
+    addgroup --gid "$GROUP_ID" "$USER_NAME"
 fi
 
 # create user if it doesn't exist
-if ! id -u billy >/dev/null 2>&1; then
-    adduser --disabled-password --gecos "" --uid "$USER_ID" --gid "$GROUP_ID" billy
+existing_user=$(getent passwd "$USER_ID" | cut -d: -f1 || true)
+if [ -z "$existing_user" ]; then
+    adduser --disabled-password --gecos "" --uid "$USER_ID" --gid "$GROUP_ID" "$USER_NAME"
+    run_user="$USER_NAME"
+else
+    run_user="$existing_user"
 fi
 
-chown -R billy:billy /app
+chown -R "$USER_ID":"$GROUP_ID" /app
 
-exec gosu billy "$@"
+exec gosu "$run_user" "$@"


### PR DESCRIPTION
## Summary
- handle existing UID/GID when creating container user
- chown using numeric IDs

## Testing
- `npm test --silent` in `backend`
- `npm test --silent -- --watchAll=false` in `frontend`


------
https://chatgpt.com/codex/tasks/task_e_6849e59d17b08331831755b046c1b5c5