### PR TITLE
Fix docker publish trigger paths

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "Dockerfile"
       - ".dockerignore"
+      - "docker-entrypoint.sh"
       - ".github/workflows/docker-publish.yml"
       - "backend/**"
       - "frontend/**"


### PR DESCRIPTION
## Summary
- ensure container publish workflow triggers when `docker-entrypoint.sh` is modified

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e88334648331a8c679541c61ee8b