### PR TITLE
Implement semver bumps and digest verification

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,22 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Bump patch version
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version patch --no-git-tag-version
+          VERSION=$(node -p "require('./package.json').version")
+          cd backend && npm version $VERSION --no-git-tag-version && cd ..
+          cd frontend && npm version $VERSION --no-git-tag-version && cd ..
+          git add package.json package-lock.json backend/package.json backend/package-lock.json frontend/package.json frontend/package-lock.json
+          git commit -m "chore: release v$VERSION"
+          git tag "v$VERSION"
+          git push origin HEAD:${GITHUB_REF#refs/heads/} --follow-tags
 
       - name: Log in to ghcr.io
         uses: docker/login-action@v2
@@ -55,3 +71,12 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.VERSION }}
             ghcr.io/${{ github.repository }}:latest
+
+      - name: Verify container digests match
+        run: |
+          version_digest=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.VERSION }} | grep Digest | head -n1 | awk '{print $2}')
+          latest_digest=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}:latest | grep Digest | head -n1 | awk '{print $2}')
+          if [ "$version_digest" != "$latest_digest" ]; then
+            echo "Digest mismatch: $version_digest vs $latest_digest"
+            exit 1
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Build stage
-FROM node:18 AS builder
+ARG NODE_VERSION=18
+FROM node:${NODE_VERSION} AS builder
 WORKDIR /app
 
 # Install backend dependencies
@@ -16,7 +17,7 @@ RUN cd frontend && npm run build
 COPY backend ./backend
 
 # Final stage
-FROM node:18-slim
+FROM node:${NODE_VERSION}-slim
 
 # Runtime user will be created based on UID/GID environment variables
 # provided when the container starts.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,15 @@ cd ../frontend && npm test -- --watchAll=false
 
 The backend uses a SQLite database stored at `backend/data/bills.db` by default. A sample JSON file is provided at `backend/data/bills_example.json` to illustrate the bill format.
 
+## Versioning
+
+This project follows [Semantic Versioning](https://semver.org/). The patch number
+is automatically incremented whenever commits land on the `main` branch. Docker
+images published by our workflow are tagged with the version as well as
+`latest`. A digest check ensures that both tags reference the same image.
+
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file
+for details.
 


### PR DESCRIPTION
## Summary
- add a Versioning section in the README
- parameterize Node base image with a single `NODE_VERSION` build ARG
- update Docker workflow to bump patch versions on pushes to `main`
- check that pushed container tags have matching digests

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f488b34083318d266ae83264f373