### PR TITLE
Improve pay period dropdown display

### DIFF
--- a/frontend/src/components/PayPeriodSelector.jsx
+++ b/frontend/src/components/PayPeriodSelector.jsx
@@ -1,7 +1,15 @@
 // src/components/PayPeriodSelector.jsx
 
 import React, { useEffect, useState, useRef } from 'react';
-import { Box, Select, MenuItem, FormControl, InputLabel, ListItemIcon } from '@mui/material';
+import {
+  Box,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  ListItemIcon,
+  Typography,
+} from '@mui/material';
 import { format } from 'date-fns-tz';
 import { getPayPeriods } from '../utils/payPeriodUtils';
 import { formatNumber } from '../utils/numberUtils';
@@ -14,7 +22,7 @@ function PayPeriodSelector({ bills, setPayPeriod }) {
   const isFirstRender = useRef(true);
 
   useEffect(() => {
-    const periods = getPayPeriods(bills, 3);
+    const periods = getPayPeriods(bills, 3, 1);
     setPayPeriods(periods);
 
     // On first render, set the selectedIndex to the current pay period
@@ -62,9 +70,13 @@ function PayPeriodSelector({ bills, setPayPeriod }) {
               <ListItemIcon>
                 <DateRangeIcon fontSize="small" />
               </ListItemIcon>
-              {format(period.start, 'MMM dd, yyyy', { timeZone })} -{' '}
-              {format(period.end, 'MMM dd, yyyy', { timeZone })} | $
-              {formatNumber(period.totalAmount)}
+              <Box sx={{ display: 'flex', flexDirection: 'column', lineHeight: 1 }}>
+                <Typography variant="body1">
+                  {format(period.start, 'MMM dd', { timeZone })} -{' '}
+                  {format(period.end, 'MMM dd', { timeZone })}
+                </Typography>
+                <Typography variant="body2">${formatNumber(period.totalAmount)}</Typography>
+              </Box>
             </MenuItem>
           ))}
         </Select>

--- a/frontend/src/utils/payPeriodUtils.js
+++ b/frontend/src/utils/payPeriodUtils.js
@@ -8,7 +8,7 @@ import {
 } from 'date-fns';
 import { utcToZonedTime } from 'date-fns-tz';
 
-export function getPayPeriods(bills, numberOfPeriods = 3) {
+export function getPayPeriods(bills, numberOfPeriods = 3, previousPeriods = 0) {
   const timeZone = 'America/Los_Angeles';
 
   // Initial payday in Pacific Time
@@ -35,8 +35,10 @@ export function getPayPeriods(bills, numberOfPeriods = 3) {
 
   // Generate the pay periods
   const payPeriods = [];
-  for (let i = 0; i < numberOfPeriods; i++) {
-    const periodStart = addDays(initialPayday, (payPeriodIndex + i) * payPeriodLength);
+  const totalPeriods = numberOfPeriods + previousPeriods;
+  const startingIndex = payPeriodIndex - previousPeriods;
+  for (let i = 0; i < totalPeriods; i++) {
+    const periodStart = addDays(initialPayday, (startingIndex + i) * payPeriodLength);
     const periodEnd = addDays(periodStart, payPeriodLength - 1);
 
     // Calculate total amount for this pay period
@@ -78,7 +80,7 @@ export function getPayPeriods(bills, numberOfPeriods = 3) {
     }, 0);
 
     payPeriods.push({
-      index: payPeriodIndex + i,
+      index: startingIndex + i,
       start: periodStart,
       end: periodEnd,
       totalAmount,


### PR DESCRIPTION
## Summary
- show one previous pay period in selector
- format dropdown options across two lines
- support retrieving previous pay periods in utility

## Testing
- `npm test`
- `cd frontend && npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6849fa16ce548331899c70570bf98083