### PR TITLE
Fix tag trigger for Docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,19 +4,6 @@ on:
   push:
     branches: ["main"]
     tags: ["v*"]
-    paths:
-      - "Dockerfile"
-      - ".dockerignore"
-      - "docker-entrypoint.sh"
-      - ".github/workflows/docker-publish.yml"
-      - "backend/**"
-      - "frontend/**"
-      - "package.json"
-      - "package-lock.json"
-      - "backend/package.json"
-      - "backend/package-lock.json"
-      - "frontend/package.json"
-      - "frontend/package-lock.json"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- remove path filter from docker build workflow so tag pushes run

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f726e9b88331adb3e315bb5f9ac4