### PR TITLE
Fix tag trigger for Docker workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,19 +4,6 @@ on:
   push:
     branches: ["main"]
     tags: ["v*"]
-    paths:
-      - "Dockerfile"
-      - ".dockerignore"
-      - "docker-entrypoint.sh"
-      - ".github/workflows/docker-publish.yml"
-      - "backend/**"
-      - "frontend/**"
-      - "package.json"
-      - "package-lock.json"
-      - "backend/package.json"
-      - "backend/package-lock.json"
-      - "frontend/package.json"
-      - "frontend/package-lock.json"
 
 jobs:
   build:
@@ -54,15 +41,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Determine version
+        if: github.ref_type == 'tag'
         id: vars
         run: |
-          if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-            echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "VERSION=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
+        if: github.ref_type == 'tag'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -73,6 +58,7 @@ jobs:
             ghcr.io/${{ github.repository }}:latest
 
       - name: Verify container digests match
+        if: github.ref_type == 'tag'
         run: |
           version_digest=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.VERSION }} | grep Digest | head -n1 | awk '{print $2}')
           latest_digest=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}:latest | grep Digest | head -n1 | awk '{print $2}')


### PR DESCRIPTION
## Summary
- remove path filter from docker build workflow so tag pushes run
- only build docker image when workflow is triggered by a tag push

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f726e9b88331adb3e315bb5f9ac4