### PR TITLE
Fix container publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,6 @@ name: Build and Publish Docker image
 on:
   push:
     branches: ["main"]
-    tags: ["v*"]
 
 jobs:
   build:
@@ -17,7 +16,7 @@ jobs:
           fetch-depth: 0
 
       - name: Bump patch version
-        if: github.actor != 'github-actions[bot]' && !startsWith(github.ref, 'refs/tags/')
+        if: github.actor != 'github-actions[bot]'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -27,8 +26,6 @@ jobs:
           cd frontend && npm version $VERSION --no-git-tag-version && cd ..
           git add package.json package-lock.json backend/package.json backend/package-lock.json frontend/package.json frontend/package-lock.json
           git commit -m "chore: release v$VERSION"
-          git tag "v$VERSION"
-          git push origin HEAD:${GITHUB_REF#refs/heads/} --follow-tags
 
       - name: Log in to ghcr.io
         uses: docker/login-action@v2
@@ -41,14 +38,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Determine version
-        if: startsWith(github.ref, 'refs/tags/')
-
+        if: github.actor != 'github-actions[bot]'
         id: vars
         run: |
-          echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$(node -p 'require("./package.json").version')" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.actor != 'github-actions[bot]'
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -59,7 +55,7 @@ jobs:
             ghcr.io/${{ github.repository }}:latest
 
       - name: Verify container digests match
-        if: startsWith(github.ref, 'refs/tags/')
+        if: github.actor != 'github-actions[bot]'
         run: |
           version_digest=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.vars.outputs.VERSION }} | grep Digest | head -n1 | awk '{print $2}')
           latest_digest=$(docker buildx imagetools inspect ghcr.io/${{ github.repository }}:latest | grep Digest | head -n1 | awk '{print $2}')
@@ -67,3 +63,11 @@ jobs:
             echo "Digest mismatch: $version_digest vs $latest_digest"
             exit 1
           fi
+
+      - name: Push release tag
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          VERSION=${{ steps.vars.outputs.VERSION }}
+          git tag "v$VERSION"
+          git push origin HEAD:${GITHUB_REF#refs/heads/}
+          git push origin "v$VERSION"

--- a/README.md
+++ b/README.md
@@ -103,9 +103,10 @@ The backend uses a SQLite database stored at `backend/data/bills.db` by default.
 ## Versioning
 
 This project follows [Semantic Versioning](https://semver.org/). The patch number
-is automatically incremented whenever commits land on the `main` branch. Docker
-images published by our workflow are tagged with the version as well as
-`latest`. A digest check ensures that both tags reference the same image.
+is automatically incremented whenever commits land on the `main` branch. Our
+container publish workflow builds the Docker image, tags it with the new version
+and `latest`, verifies the digests match, then pushes the release commit and tag
+back to the repository.
 
 ## License
 


### PR DESCRIPTION
## Summary
- fix docker-publish workflow so version bump and container build happen in one run
- clarify release automation in README

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a03e1b4288331a9dbca2e3b697787