### PR TITLE
Implement dev branch container workflow

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -1,0 +1,34 @@
+name: Build and Publish Dev Docker image
+
+on:
+  push:
+    branches: ["dev"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:dev
+            ghcr.io/${{ github.repository }}:dev-${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ container publish workflow builds the Docker image, tags it with the new version
 and `latest`, verifies the digests match, then pushes the release commit and tag
 back to the repository.
 
+Commits pushed to the `dev` branch trigger a similar workflow that builds the
+container and pushes images tagged `dev` and `dev-<commit>` for testing.
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file


### PR DESCRIPTION
## Summary
- enable container builds from the `dev` branch
- document the new dev release chain

## Testing
- `npm test`
- `npm run install-all`

------
https://chatgpt.com/codex/tasks/task_e_684b10a611d08331a051c85070ba94ec