### PR TITLE
Improve Docker build reliability

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+fetch-retries=5
+fetch-retry-factor=2
+fetch-retry-mintimeout=10000
+fetch-retry-maxtimeout=120000

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,15 @@
 ARG NODE_VERSION=18
 FROM node:${NODE_VERSION} AS builder
 WORKDIR /app
+COPY .npmrc .
 
 # Install backend dependencies
 COPY backend/package*.json ./backend/
-RUN cd backend && npm install --production
+RUN cd backend && npm ci --production
 
 # Build frontend
 COPY frontend/package*.json ./frontend/
-RUN cd frontend && npm install
+RUN cd frontend && npm ci
 COPY frontend ./frontend
 RUN cd frontend && npm run build
 


### PR DESCRIPTION
## Summary
- add `.npmrc` with retry settings
- copy `.npmrc` into Docker build and use `npm ci`

## Testing
- `npm run install-all`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b3b0ff0388331a4e94315b5836341