### PR TITLE
Add settings page for bill tracker

### DIFF
--- a/frontend/src/components/PayPeriodSelector.jsx
+++ b/frontend/src/components/PayPeriodSelector.jsx
@@ -16,7 +16,7 @@ import { getPayPeriods, calculatePayPeriodIndex } from '../utils/payPeriodUtils'
 import { formatNumber } from '../utils/numberUtils';
 import DateRangeIcon from '@mui/icons-material/DateRange';
 
-function PayPeriodSelector({ bills, setPayPeriod }) {
+function PayPeriodSelector({ bills, setPayPeriod, pastPeriods = 0, futurePeriods = 4 }) {
   const [payPeriods, setPayPeriods] = useState([]);
   const [selectedIndex, setSelectedIndex] = useState('');
   const timeZone = 'America/Los_Angeles';
@@ -24,7 +24,7 @@ function PayPeriodSelector({ bills, setPayPeriod }) {
   const currentIndex = calculatePayPeriodIndex(new Date());
 
   useEffect(() => {
-    const periods = getPayPeriods(bills, 4, 1);
+    const periods = getPayPeriods(bills, futurePeriods + 1, pastPeriods);
     setPayPeriods(periods);
 
     // On first render, select the current pay period
@@ -55,7 +55,7 @@ function PayPeriodSelector({ bills, setPayPeriod }) {
         }
       }
     }
-  }, [bills, selectedIndex, setPayPeriod, currentIndex]);
+  }, [bills, selectedIndex, setPayPeriod, currentIndex, pastPeriods, futurePeriods]);
 
   const handleChange = (event) => {
     const index = event.target.value;

--- a/frontend/src/components/SettingsDialog.jsx
+++ b/frontend/src/components/SettingsDialog.jsx
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Box,
+} from '@mui/material';
+
+function SettingsDialog({ open, onClose, settings, saveSettings }) {
+  const [title, setTitle] = useState(settings.title || 'Billy');
+  const [past, setPast] = useState(settings.pastPeriods);
+  const [future, setFuture] = useState(settings.futurePeriods);
+
+  useEffect(() => {
+    setTitle(settings.title);
+    setPast(settings.pastPeriods);
+    setFuture(settings.futurePeriods);
+  }, [settings]);
+
+  const handleSave = () => {
+    saveSettings({ title, pastPeriods: past, futurePeriods: future });
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} aria-labelledby="settings-dialog-title">
+      <DialogTitle id="settings-dialog-title">Settings</DialogTitle>
+      <DialogContent>
+        <TextField
+          label="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          fullWidth
+          margin="normal"
+        />
+        <FormControl fullWidth margin="normal">
+          <InputLabel>Past Pay Periods</InputLabel>
+          <Select
+            label="Past Pay Periods"
+            value={past}
+            onChange={(e) => setPast(parseInt(e.target.value, 10))}
+          >
+            {[0, 1, 2, 3].map((n) => (
+              <MenuItem key={n} value={n}>
+                {n}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl fullWidth margin="normal">
+          <InputLabel>Future Pay Periods</InputLabel>
+          <Select
+            label="Future Pay Periods"
+            value={future}
+            onChange={(e) => setFuture(parseInt(e.target.value, 10))}
+          >
+            {Array.from({ length: 7 }, (_, i) => i).map((n) => (
+              <MenuItem key={n} value={n}>
+                {n}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" color="primary">
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+export default SettingsDialog;


### PR DESCRIPTION
## Summary
- implement a new `SettingsDialog` component
- load/save title and pay period counts
- provide settings and theme controls in `App`
- pass pay period settings to `PayPeriodSelector`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e91bb8418833186a065e1312ac9b7