### PR TITLE
Persist settings in database

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -10,7 +10,7 @@ const dbPath = process.env.DB_PATH || path.join(dataDir, 'bills.db');
 
 const db = new Database(dbPath);
 
-// Initialize table
+// Initialize tables
 const init = `CREATE TABLE IF NOT EXISTS bills (
   id INTEGER PRIMARY KEY,
   name TEXT,
@@ -21,6 +21,10 @@ const init = `CREATE TABLE IF NOT EXISTS bills (
   autoPay INTEGER,
   paymentHistory TEXT,
   dueDate TEXT
+);
+CREATE TABLE IF NOT EXISTS settings (
+  key TEXT PRIMARY KEY,
+  value TEXT
 )`;
 
 db.exec(init);

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "jest --coverage"
+    "test": "jest --coverage --runInBand"
   },
   "dependencies": {
     "body-parser": "^1.20.3",

--- a/backend/tests/settings.test.js
+++ b/backend/tests/settings.test.js
@@ -1,0 +1,56 @@
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+let db;
+
+const testDataDir = path.join(__dirname, 'data');
+const testDbPath = path.join(testDataDir, 'settings.test.db');
+
+let app;
+
+beforeAll(() => {
+  if (!fs.existsSync(testDataDir)) {
+    fs.mkdirSync(testDataDir);
+  }
+  process.env.DATA_DIR = testDataDir;
+  process.env.DB_PATH = testDbPath;
+  db = require('../db');
+});
+
+beforeEach(() => {
+  jest.resetModules();
+  app = require('../index');
+  db.exec('DELETE FROM settings');
+});
+
+afterAll(() => {
+  db.close();
+  if (fs.existsSync(testDataDir)) {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  }
+});
+
+describe('GET /api/settings', () => {
+  it('should return empty object when no settings saved', async () => {
+    const res = await request(app).get('/api/settings');
+    expect(res.statusCode).toEqual(200);
+    expect(res.body).toEqual({});
+  });
+});
+
+describe('POST /api/settings', () => {
+  it('should save and return settings', async () => {
+    const settings = { title: 'Test', pastPeriods: 2, futurePeriods: 3 };
+    const res = await request(app).post('/api/settings').send(settings);
+    expect(res.statusCode).toEqual(200);
+    expect(res.body.message).toBe('Settings saved successfully.');
+
+    const getRes = await request(app).get('/api/settings');
+    expect(getRes.statusCode).toEqual(200);
+    expect(getRes.body).toEqual({
+      title: 'Test',
+      pastPeriods: '2',
+      futurePeriods: '3',
+    });
+  });
+});

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -168,18 +168,45 @@ function App() {
     setDarkMode(savedTheme);
   }, []);
 
-  // Initialize app settings from localStorage
+  // Initialize app settings from server with localStorage fallback
   useEffect(() => {
-    const savedTitle = localStorage.getItem('appTitle') || 'Billy';
-    const savedPast = parseInt(localStorage.getItem('pastPeriods') || '1', 10);
-    const savedFuture = parseInt(
-      localStorage.getItem('futurePeriods') || '4',
-      10
-    );
-    setTitle(savedTitle);
-    setPastPeriods(savedPast);
-    setFuturePeriods(savedFuture);
-    document.title = savedTitle;
+    axios
+      .get('/api/settings')
+      .then((response) => {
+        const data = response.data || {};
+        const fetchedTitle =
+          data.title || localStorage.getItem('appTitle') || 'Billy';
+        const fetchedPast = parseInt(
+          data.pastPeriods || localStorage.getItem('pastPeriods') || '1',
+          10
+        );
+        const fetchedFuture = parseInt(
+          data.futurePeriods || localStorage.getItem('futurePeriods') || '4',
+          10
+        );
+        setTitle(fetchedTitle);
+        setPastPeriods(fetchedPast);
+        setFuturePeriods(fetchedFuture);
+        document.title = fetchedTitle;
+        localStorage.setItem('appTitle', fetchedTitle);
+        localStorage.setItem('pastPeriods', fetchedPast);
+        localStorage.setItem('futurePeriods', fetchedFuture);
+      })
+      .catch(() => {
+        const savedTitle = localStorage.getItem('appTitle') || 'Billy';
+        const savedPast = parseInt(
+          localStorage.getItem('pastPeriods') || '1',
+          10
+        );
+        const savedFuture = parseInt(
+          localStorage.getItem('futurePeriods') || '4',
+          10
+        );
+        setTitle(savedTitle);
+        setPastPeriods(savedPast);
+        setFuturePeriods(savedFuture);
+        document.title = savedTitle;
+      });
   }, []);
 
   // Persist title changes
@@ -213,6 +240,11 @@ function App() {
     setTitle(title);
     setPastPeriods(pastPeriods);
     setFuturePeriods(futurePeriods);
+    axios
+      .post('/api/settings', { title, pastPeriods, futurePeriods })
+      .catch((error) => {
+        console.error('There was an error saving settings!', error);
+      });
   };
 
   /**


### PR DESCRIPTION
## Summary
- create settings table and endpoints for database persistence
- fetch settings from backend and POST updates
- ensure backend tests run sequentially
- add backend tests for settings API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e9a154d888331a010f427d59144ec